### PR TITLE
Configurable timeouts

### DIFF
--- a/server/server.hpp
+++ b/server/server.hpp
@@ -25,6 +25,14 @@ class rpc_handler;
 class service;
 class user;
 
+struct timeout_config
+{
+    /// websocket handshake timeout, default: 30s
+    std::chrono::seconds handshake_timeout;
+    /// websocket handshake timeout, default: 300s
+    std::chrono::seconds idle_timeout;
+};
+
 //------------------------------------------------------------------------------
 
 /** An instance of the lounge server.
@@ -86,6 +94,10 @@ public:
     virtual
     void
     stop() = 0;
+
+    virtual
+    timeout_config
+    timeouts() const = 0;
 };
 
 //------------------------------------------------------------------------------

--- a/server/ws_user.cpp
+++ b/server/ws_user.cpp
@@ -76,10 +76,13 @@ public:
     void
     run(websocket::request_type req)
     {
+        websocket::stream_base::timeout timeout{};
+        auto cfg = srv_.timeouts();
+        timeout.handshake_timeout = cfg.handshake_timeout;
+        timeout.idle_timeout = cfg.idle_timeout;
+        timeout.keep_alive_pings = true;
         // Apply settings to stream
-        impl()->ws().set_option(
-            websocket::stream_base::timeout::suggested(
-                beast::role_type::server));
+        impl()->ws().set_option(timeout);
 
         // Limit the maximum incoming message size
         impl()->ws().read_message_max(64 * 1024);

--- a/static/dockerconfig.json
+++ b/static/dockerconfig.json
@@ -8,8 +8,10 @@
     ],
 
     "server": {
-      "threads" : 5,
-      "doc-root" : "var/beast-lounge/www"
+      "threads" : 1,
+      "doc-root" : "var/beast-lounge/www",
+      "handshake_timeout_seconds" : 50,
+      "idle_timeout_seconds" : 60
     },
 
     "log" : {


### PR DESCRIPTION
Handshake and idle timeouts are now loaded from the configuration file. This prevents connections from timing out on Heroku (where the app is required to send at least 1 byte every 55s).